### PR TITLE
review

### DIFF
--- a/lib/core/allocator.c
+++ b/lib/core/allocator.c
@@ -317,7 +317,7 @@ void *alloc_allocate(size_t size, allocMode mode)
     void *ptr;
     switch (mode)
     {
-    case UNITITIALIZED:
+    case UNINITIALIZED:
         ptr = malloc(size);
 
         break;

--- a/lib/core/io.c
+++ b/lib/core/io.c
@@ -68,7 +68,7 @@ void file_size(file pFile)
 file file_new(string pFPath)
 {
     size_t size = sizeof(struct io_file);
-    file pFile = Allocator.alloc(sizeof(struct io_file), UNITITIALIZED);
+    file pFile = Allocator.alloc(sizeof(struct io_file), UNINITIALIZED);
     if (!pFile)
     {
         //  handle error
@@ -173,7 +173,7 @@ void get_file_path(file pFile, string *pFullPath)
 //      ==================== Directory Definitions ==========================
 directory dir_new(string pPath)
 {
-    directory pDir = Allocator.alloc(sizeof(struct io_dir), UNITITIALIZED);
+    directory pDir = Allocator.alloc(sizeof(struct io_dir), UNINITIALIZED);
     string slash = strrchr(pPath, '/');
     if (!slash)
     {

--- a/lib/core/io_stream.c
+++ b/lib/core/io_stream.c
@@ -96,7 +96,7 @@ void get_friendly_mode(iomode mode, string *outMode)
 }
 stream strm_new(string pPath)
 {
-    stream pStream = Allocator.alloc(sizeof(struct io_stream), UNITITIALIZED);
+    stream pStream = Allocator.alloc(sizeof(struct io_stream), UNINITIALIZED);
     pStream->source = pPath;
     pStream->mode = NO_MODE;
     pStream->error = NONE;

--- a/lib/core/test/alloc_tests.c
+++ b/lib/core/test/alloc_tests.c
@@ -83,7 +83,7 @@ void allocate_item()
 {
     writeln("Allocate mem for item");
 
-    target2 t2 = Allocator.alloc(sizeof(struct test2), UNITITIALIZED);
+    target2 t2 = Allocator.alloc(sizeof(struct test2), UNINITIALIZED);
     assert(t2 != NULL);
     assert(Allocator.count() == 1);
 
@@ -134,7 +134,7 @@ void multiple_allocs()
 
     target2 t2A = Allocator.alloc(sizeof(struct test2), INITIALIZED);
     target1 t1A = Allocator.alloc(sizeof(struct test1), INITIALIZED);
-    target2 t2B = Allocator.alloc(sizeof(struct test2), UNITITIALIZED);
+    target2 t2B = Allocator.alloc(sizeof(struct test2), UNINITIALIZED);
     __output_allocator_info();
 
     t1A->id = expId;

--- a/open/allocator.h
+++ b/open/allocator.h
@@ -12,7 +12,7 @@
 enum Alloc_Mode
 {
     INITIALIZED,
-    UNITITIALIZED
+    UNINITIALIZED
 };
 
 struct Mem_Block

--- a/open/types.h
+++ b/open/types.h
@@ -13,5 +13,6 @@ typedef unsigned short ushort;
 typedef char sbyte;
 
 typedef char *string;
+typedef void *object;
 
 #endif // _OPEN_TYPES_H


### PR DESCRIPTION
code review:
corrected misspellings
added type: object (void *)

in terms of a default reference _object_, essentially, what `void *` is ... so:
``` c
  typedef void *object;
```